### PR TITLE
Fix service startup loops

### DIFF
--- a/src/smartmoney_bot/common/async_utils.py
+++ b/src/smartmoney_bot/common/async_utils.py
@@ -1,0 +1,33 @@
+import asyncio
+from typing import Any
+
+import asyncpg
+from redis import asyncio as aioredis
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+async def wait_for_postgres(url: str, retries: int = 30, delay: float = 1.0) -> asyncpg.Connection:
+    """Wait for Postgres to become available and return a connection."""
+    for attempt in range(1, retries + 1):
+        try:
+            conn = await asyncpg.connect(url)
+            return conn
+        except Exception as exc:  # pragma: no cover - best effort connect
+            log.info("postgres not ready", attempt=attempt, err=str(exc))
+            await asyncio.sleep(delay)
+    raise RuntimeError("Cannot connect to Postgres")
+
+
+async def wait_for_redis(url: str, retries: int = 30, delay: float = 1.0) -> aioredis.Redis:
+    """Wait for Redis to become available and return a client."""
+    for attempt in range(1, retries + 1):
+        try:
+            redis = aioredis.from_url(url, decode_responses=True)
+            await redis.ping()
+            return redis
+        except Exception as exc:  # pragma: no cover - best effort connect
+            log.info("redis not ready", attempt=attempt, err=str(exc))
+            await asyncio.sleep(delay)
+    raise RuntimeError("Cannot connect to Redis")

--- a/src/smartmoney_bot/metrics/metric_engine.py
+++ b/src/smartmoney_bot/metrics/metric_engine.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import structlog
 from redis.asyncio import Redis
+from ..common.async_utils import wait_for_redis
 
 from .buffer import RingBuffer
 from .config import Config
@@ -21,7 +22,7 @@ GROUP = "metricscg"
 
 async def engine_task() -> None:
     cfg = Config()
-    redis = Redis.from_url(cfg.REDIS_URL)
+    redis = await wait_for_redis(cfg.REDIS_URL)
     try:
         await redis.xgroup_create(RAW_STREAM, GROUP, mkstream=True, id="$")
     except Exception:
@@ -88,3 +89,7 @@ async def engine_task() -> None:
 
 def run() -> None:
     asyncio.run(engine_task())
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add retry helpers for Postgres and Redis
- use retry logic and add `__main__` blocks for orchestrator and metrics
- ensure metric engine waits for Redis before starting

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d133ef6e0832bbec5048a0cf22662