### PR TITLE
Fix Docker startup errors and update tests

### DIFF
--- a/src/smartmoney_bot/alert/alertbot.py
+++ b/src/smartmoney_bot/alert/alertbot.py
@@ -6,6 +6,8 @@ import time
 
 from redis import asyncio as aioredis
 import asyncpg
+
+from ..common.async_utils import wait_for_postgres
 import structlog
 
 from .telegram import send_alert
@@ -39,7 +41,7 @@ async def watch_heartbeats(redis: aioredis.Redis) -> None:
 
 async def run() -> None:
     redis = aioredis.from_url(REDIS_URL, decode_responses=True)  # type: ignore[no-untyped-call]
-    conn = await asyncpg.connect(DATABASE_URL)
+    conn = await wait_for_postgres(DATABASE_URL)
     await asyncio.gather(watch_trades(conn), watch_heartbeats(redis))
 
 

--- a/src/smartmoney_bot/orchestrator/engine.py
+++ b/src/smartmoney_bot/orchestrator/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from typing import cast


### PR DESCRIPTION
## Summary
- fix orchestrator engine import
- make alertbot wait for Postgres
- handle missing `data` field in metric engine
- ensure tests run with redis fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d26b0afe8832b978b05f1868ed997