### PR TITLE
Fix orchestrator metrics parsing

### DIFF
--- a/src/smartmoney_bot/metrics/metric_engine.py
+++ b/src/smartmoney_bot/metrics/metric_engine.py
@@ -78,14 +78,15 @@ async def engine_task() -> None:
                 last_minute[symbol] = minute
                 view = buf.view(cfg.BUFFER_SIZE if buf.full else buf.idx)
                 metrics = compute_all_metrics(view)
-                message = {
+                message: dict[str, Any] = {
                     "ts": ts,
                     "symbol": symbol,
-                    "metrics": metrics,
+                    "price": frame["price"],
+                    **metrics,
                 }
                 await redis.xadd(
                     METRIC_STREAM,
-                    {"data": json.dumps(message)},
+                    message,
                     maxlen=100000,
                     approximate=True,
                 )


### PR DESCRIPTION
## Summary
- Flatten metrics engine output instead of stringified JSON
- Orchestrator parses and validates stream payload, logging non-numeric metrics

## Testing
- `PYTHONPATH=src pytest tests/test_orchestrator.py tests/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688de2f01e2c832b952f5a51a6527838