### PR TITLE
Add __main__ entry point for config CLI

### DIFF
--- a/src/cli/config_cli.py
+++ b/src/cli/config_cli.py
@@ -124,3 +124,6 @@ def apply() -> None:
         shutil.copy(LIVE_FILE, HISTORY_DIR / f"live_{ts}.yml")
     shutil.move(STAGING_FILE, LIVE_FILE)
     typer.echo("Applied configuration")
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- allow running configuration CLI as a module

## Testing
- `PYTHONPATH=src python -m cli.config_cli`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e18a139f8832ba3bb4fe6013bf20b