### PR TITLE
Expose new bot and orchestrator scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,6 @@ pytest-docker = "^3.2.3"
 python-dateutil = "^2.9.0"
 
 [tool.poetry.scripts]
-bot = "smartmoney_bot.orchestrator.engine:main"
+bot = "cli.config_cli:app"
+orchestrator = "smartmoney_bot.orchestrator.engine:main"
 backtest = "smartmoney_bot.backtest.sim:cli"


### PR DESCRIPTION
## Summary
- adjust Poetry scripts: point `bot` to `cli.config_cli:app` and add `orchestrator` entry for the engine

## Testing
- `poetry install`
- `poetry run bot --help`


------
https://chatgpt.com/codex/tasks/task_e_688e18a30d60832ba39d2105aede288a