### PR TITLE
Fix Grafana dashboard volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./docker/grafana-dashboard.jsondocker:/etc/grafana/provisioning/dashboard.json
+      - ./docker/grafana-dashboard.json:/etc/grafana/provisioning/dashboard.json
   alertbot:
     build: .
     environment:


### PR DESCRIPTION
## Summary
- correct Grafana dashboard volume mapping in docker-compose.yml

## Testing
- `pytest`
- `docker-compose up -d grafana` *(fails: Error while fetching server API version: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e18a43784832ba0f5bdffbea35527