### PR TITLE
Mount parquet volume for collector and metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,16 @@ services:
     build: .
     environment:
       SERVICE: smartmoney_bot.collector.collector_service
+    volumes:
+      - ./parquets:/parquets
     depends_on:
       - redis
   metrics:
     build: .
     environment:
       SERVICE: smartmoney_bot.metrics.metric_engine
+    volumes:
+      - ./parquets:/parquets
     depends_on:
       - redis
   orchestrator:


### PR DESCRIPTION
## Summary
- Mount `./parquets` into collector container at `/parquets`
- Mount `./parquets` into metrics container at `/parquets`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ops'; No module named 'cli')*
- `docker-compose up -d collector metrics` *(fails: Error while fetching server API version: FileNotFoundError: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e18a4d7a8832bbb00a34b05987789