### PR TITLE
Add parquet export for minute metrics

### DIFF
--- a/src/smartmoney_bot/metrics/config.py
+++ b/src/smartmoney_bot/metrics/config.py
@@ -9,3 +9,5 @@ class Config:
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://redis:6379/0")
     BUFFER_SIZE: int = int(os.getenv("BUFFER_SIZE", "1440"))
     ATR_PERIOD: int = int(os.getenv("ATR_PERIOD", "14"))
+    WRITE_PERIOD: int = int(os.getenv("PARQUET_WRITE_PERIOD", "1"))
+    PARQUET_DIR: str = os.getenv("PARQUET_DIR", "parquets")

--- a/tests/test_metrics_parquet.py
+++ b/tests/test_metrics_parquet.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+import pandas as pd
+
+from smartmoney_bot.metrics.config import Config
+from smartmoney_bot.metrics.metric_engine import write_metrics_row
+
+
+def test_write_metrics_row(tmp_path) -> None:
+    cfg = Config(PARQUET_DIR=str(tmp_path))
+    ts = int(datetime(2024, 1, 1).timestamp() * 1000)
+    msg1 = {"ts": ts, "symbol": "BTCUSDT", "price": 1.0}
+    write_metrics_row(msg1, cfg)
+
+    date_str = "20240101"
+    file_path = tmp_path / f"minute_{date_str}_BTCUSDT.parquet"
+    assert file_path.exists()
+    df = pd.read_parquet(file_path)
+    assert df.iloc[0]["price"] == 1.0
+
+    msg2 = {"ts": ts + 60000, "symbol": "BTCUSDT", "price": 2.0}
+    write_metrics_row(msg2, cfg)
+    df2 = pd.read_parquet(file_path)
+    assert len(df2) == 2
+    assert df2.iloc[1]["price"] == 2.0
+


### PR DESCRIPTION
## Summary
- write per-minute metrics to date/symbol parquet files
- allow configuring parquet directory and write period
- test parquet writer behavior

## Testing
- `ruff check src/smartmoney_bot/metrics/metric_engine.py src/smartmoney_bot/metrics/config.py tests/test_metrics_parquet.py`
- `pytest tests/test_metrics_parquet.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_688e18a5486c832b8fe6ce0c306bcf88