### PR TITLE
feat: load env variables for compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,19 @@ version: "3"
 services:
   redis:
     image: redis:7
+    env_file: .env
     ports:
       - "6379:6379"
   postgres:
     image: postgres:16
+    env_file: .env
     environment:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
   collector:
     build: .
+    env_file: .env
     environment:
       SERVICE: smartmoney_bot.collector.collector_service
     volumes:
@@ -20,6 +23,7 @@ services:
       - redis
   metrics:
     build: .
+    env_file: .env
     environment:
       SERVICE: smartmoney_bot.metrics.metric_engine
     volumes:
@@ -28,6 +32,7 @@ services:
       - redis
   orchestrator:
     build: .
+    env_file: .env
     environment:
       SERVICE: smartmoney_bot.orchestrator.engine
     depends_on:
@@ -35,18 +40,21 @@ services:
       - postgres
   prometheus:
     image: prom/prometheus
+    env_file: .env
     volumes:
       - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
   grafana:
     image: grafana/grafana
+    env_file: .env
     ports:
       - "3000:3000"
     volumes:
       - ./docker/grafana-dashboard.json:/etc/grafana/provisioning/dashboard.json
   alertbot:
     build: .
+    env_file: .env
     environment:
       SERVICE: smartmoney_bot.alert.alertbot
     depends_on:


### PR DESCRIPTION
## Summary
- allow services to load env variables from `.env`

## Testing
- `docker compose config`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ops'; No module named 'cli')*


------
https://chatgpt.com/codex/tasks/task_e_688e20505994832bb8f357767fdabc37