### PR TITLE
Limit collector to two coins and add export script

### DIFF
--- a/scripts/export_parquet.py
+++ b/scripts/export_parquet.py
@@ -1,0 +1,42 @@
+import os
+import json
+import pandas as pd
+import redis
+
+FIELDS = [
+    "symbol",
+    "price",
+    "volume",
+    "open_interest",
+    "funding_rate",
+    "liquidation_notional",
+    "timestamp",
+]
+COINS = ["BTCUSDT", "ETHUSDT"]  # Coin limit: 2
+
+
+def main() -> None:
+    r = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
+    rows = []
+    for m in r.xrange("market.raw", "-", "+", count=1000):
+        data = json.loads(m[1][b"data"])
+        row = {}
+        for field in FIELDS:
+            value = data.get(field)
+            if isinstance(value, (list, dict)):
+                value = json.dumps(value)
+            row[field] = value
+        if row["symbol"] in COINS:
+            rows.append(row)
+
+    for symbol in COINS:
+        df = pd.DataFrame([row for row in rows if row["symbol"] == symbol])
+        if not df.empty:
+            df = df.convert_dtypes()
+            out = f"parquets/minute_2024-03-19_{symbol}.parquet"
+            df.to_parquet(out)
+            print(f"Saved {len(df)} rows to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smartmoney_bot/collector/config.py
+++ b/src/smartmoney_bot/collector/config.py
@@ -8,12 +8,12 @@ from dotenv import load_dotenv
 @dataclass(slots=True)
 class Config:
     redis_url: str = "redis://redis:6379/0"
-    coin_limit: int = 50
+    coin_limit: int = 2
 
 
 def from_env() -> Config:
     load_dotenv()
     return Config(
         redis_url=os.getenv("REDIS_URL", "redis://redis:6379/0"),
-        coin_limit=int(os.getenv("COIN_LIMIT", "50")),
+        coin_limit=int(os.getenv("COIN_LIMIT", "2")),
     )

--- a/src/smartmoney_bot/common/config.py
+++ b/src/smartmoney_bot/common/config.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - fallback if pydantic stubs missing
 
 class CollectorConfig(BaseModel):
     redis_url: str = Field(default="redis://redis:6379/0")
-    coin_limit: int = Field(default=50)
+    coin_limit: int = Field(default=2)
 
 
 class MetricsConfig(BaseModel):


### PR DESCRIPTION
## Summary
- default collector coin limit reduced to 2
- add helper script to export Redis market data into Parquet files

## Testing
- `poetry run ruff check scripts/export_parquet.py src/smartmoney_bot/collector/config.py src/smartmoney_bot/common/config.py`
- `poetry run black scripts/export_parquet.py src/smartmoney_bot/collector/config.py src/smartmoney_bot/common/config.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f966e4d1c832b9429da99fdd409d8