### PR TITLE
Make CoinGecko universe size configurable

### DIFF
--- a/src/smartmoney_bot/collector/__init__.py
+++ b/src/smartmoney_bot/collector/__init__.py
@@ -9,7 +9,7 @@ import structlog
 from redis.asyncio import Redis
 
 from .binance_ws import LIQUIDATION_STREAM, TICKER_STREAM, kline_stream_url
-from .config import Config
+from .config import Config, from_env
 from .redispub import publish
 from .universe import fetch_top50
 
@@ -31,7 +31,7 @@ class Collector:
 
     async def _ticker_ws(self, redis: Redis) -> None:
         async for msg in self._ws_iter(TICKER_STREAM):
-            #print("Gelen msg:", msg, type(msg)) #DEBUG
+            # print("Gelen msg:", msg, type(msg)) #DEBUG
             for item in msg:
 
                 ts = int(float(item["E"]))
@@ -39,7 +39,7 @@ class Collector:
                 await publish(
                     redis,
                     dict(Message(ts=ts, symbol=symbol, feed="ticker", payload=msg)),
-            )
+                )
 
     async def _kline_ws(self, redis: Redis, symbols: List[str]) -> None:
         url = kline_stream_url(symbols)
@@ -82,7 +82,7 @@ class Collector:
 
     async def run(self) -> None:
         self.redis = Redis.from_url(self.cfg.redis_url)
-        symbols = await fetch_top50()
+        symbols = await fetch_top50(limit=self.cfg.coin_limit)
         logger.info("universe", count=len(symbols))
         tasks = [
             self._ticker_ws(self.redis),
@@ -98,7 +98,7 @@ class Collector:
 
 
 def run() -> None:
-    cfg = Config()
+    cfg = from_env()
     collector = Collector(cfg)
     asyncio.run(collector.run())
 

--- a/src/smartmoney_bot/collector/universe.py
+++ b/src/smartmoney_bot/collector/universe.py
@@ -9,21 +9,23 @@ import aiohttp
 
 
 async def fetch_top50(
+    limit: int = 50,
     use_cache: bool = False,
     cache_path: Path | None = None,
 ) -> list[str]:
-    """Fetch top 50 symbols from CoinGecko or load from cache."""
+    """Fetch top ``limit`` symbols from CoinGecko or load from cache."""
     if use_cache or os.getenv("COLLECTOR_OFFLINE"):
         if not cache_path:
             raise ValueError("cache_path required when using cache")
         with cache_path.open("r") as f:
-            return cast(list[str], json.load(f))
+            data = cast(list[str], json.load(f))
+        return data[:limit]
 
     url = "https://api.coingecko.com/api/v3/coins/markets"
     params = {
         "vs_currency": "usd",
         "order": "market_cap_desc",
-        "per_page": "50",
+        "per_page": str(limit),
         "page": "1",
         "sparkline": "false",
     }
@@ -33,4 +35,4 @@ async def fetch_top50(
     symbols = [item["symbol"].upper() + "USDT" for item in data]
     if cache_path:
         cache_path.write_text(json.dumps(symbols, indent=2))
-    return symbols
+    return symbols[:limit]

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -17,6 +17,14 @@ async def test_universe_fetch(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_universe_fetch_limit(tmp_path) -> None:
+    os.environ["COLLECTOR_OFFLINE"] = "1"
+    fixtures = Path("tests/fixtures/coingecko_top50.json")
+    symbols = await fetch_top50(limit=10, use_cache=True, cache_path=fixtures)
+    assert len(symbols) == 10
+
+
+@pytest.mark.asyncio
 async def test_stream_insert(tmp_path) -> None:
     redis = FakeRedis()
     msg = {"ts": 1, "symbol": "TEST", "feed": "ticker", "payload": {"x": 1}}


### PR DESCRIPTION
## Summary
- allow specifying number of coins to fetch from CoinGecko
- wire collector run helper to use env-based configuration
- add test ensuring coin limit is respected

## Testing
- `ruff check src/smartmoney_bot/collector/universe.py src/smartmoney_bot/collector/__init__.py tests/test_collector.py`
- `PYTHONPATH=src pytest tests/test_collector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890585c16b4832b8318afeae50f95be