### PR TITLE
Enable configurable Redis stream maxlen

### DIFF
--- a/src/smartmoney_bot/collector/__init__.py
+++ b/src/smartmoney_bot/collector/__init__.py
@@ -39,7 +39,8 @@ class Collector:
                 await publish(
                     redis,
                     dict(Message(ts=ts, symbol=symbol, feed="ticker", payload=msg)),
-            )
+                    maxlen=self.cfg.redis_maxlen,
+                )
 
     async def _kline_ws(self, redis: Redis, symbols: List[str]) -> None:
         url = kline_stream_url(symbols)
@@ -50,6 +51,7 @@ class Collector:
             await publish(
                 redis,
                 dict(Message(ts=ts, symbol=symbol, feed="kline", payload=msg)),
+                maxlen=self.cfg.redis_maxlen,
             )
 
     async def _liquidation_ws(self, redis: Redis) -> None:
@@ -60,6 +62,7 @@ class Collector:
             await publish(
                 redis,
                 dict(Message(ts=ts, symbol=symbol, feed="liquidation", payload=msg)),
+                maxlen=self.cfg.redis_maxlen,
             )
 
     async def _ws_iter(self, url: str, key: str | None = None) -> AsyncIterator[Any]:

--- a/src/smartmoney_bot/collector/config.py
+++ b/src/smartmoney_bot/collector/config.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 class Config:
     redis_url: str = "redis://redis:6379/0"
     coin_limit: int = 50
+    redis_maxlen: int = 100000
 
 
 def from_env() -> Config:
@@ -16,4 +17,5 @@ def from_env() -> Config:
     return Config(
         redis_url=os.getenv("REDIS_URL", "redis://redis:6379/0"),
         coin_limit=int(os.getenv("COIN_LIMIT", "50")),
+        redis_maxlen=int(os.getenv("REDIS_MAXLEN", "100000")),
     )

--- a/src/smartmoney_bot/collector/redispub.py
+++ b/src/smartmoney_bot/collector/redispub.py
@@ -9,7 +9,9 @@ STREAM = "market.raw"
 MAXLEN = 100000
 
 
-async def publish(redis: Redis, message: Dict[str, Any]) -> None:
+async def publish(
+    redis: Redis, message: Dict[str, Any], *, maxlen: int = MAXLEN
+) -> None:
     await redis.xadd(
-        STREAM, {"data": json.dumps(message)}, maxlen=MAXLEN, approximate=True
+        STREAM, {"data": json.dumps(message)}, maxlen=maxlen, approximate=True
     )


### PR DESCRIPTION
## Summary
- allow configuring Redis stream max length via config
- pass configured maxlen to stream publishing

## Testing
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: aiohttp, pandas, fakeredis, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890585f8690832bbfe9b406449ff6a4